### PR TITLE
Allow \textcite, \autocite and \citeauthor

### DIFF
--- a/exe/dblpbib
+++ b/exe/dblpbib
@@ -24,7 +24,7 @@ class DBLPCLI
 	def get_keys(file)
 		IO.read(file)
 			.gsub(/(?<!\\)%.*$/, '')
-			.scan(/\\cite(\[[^\]]+\])?\{([^\}]+)\}/)
+			.scan(/\\(auto|text)?cite(author)?(\[[^\]]+\])?\{([^\}]+)\}/)
 			.map(&:pop)
 			.flat_map { |keyset| keyset.split(',') }
 			.map(&:strip)


### PR DESCRIPTION
(these are richer commands than raw \cite)