### PR TITLE
Use HTTPS link to dblp

### DIFF
--- a/exe/dblpbib
+++ b/exe/dblpbib
@@ -61,7 +61,7 @@ class DBLPCLI
 					begin
 						File.write(
 							path,
-							open("http://dblp.uni-trier.de/rec/bib1/#{key}.bib").read
+							open("https://dblp.uni-trier.de/rec/bib1/#{key}.bib").read
 						)
 					rescue OpenURI::HTTPError => e
 						puts "Failed to fetch key #{key} (#{e}) -- " \


### PR DESCRIPTION
More security is better! DBLP redirects http to https anyway.